### PR TITLE
Update timelinejs.json

### DIFF
--- a/assets/data/timelinejs.json
+++ b/assets/data/timelinejs.json
@@ -4,7 +4,8 @@
 # Curate the timeline by adding a "where" expression to the assign on the first line.
 # For details, see https://collectionbuilder.github.io/cb-docs/docs/advanced/timelinejs/  
 ---
-{%- assign items = site.data[site.metadata] | where_exp: 'item','item.format contains "image"' -%}
+{%- assign items = site.data[site.metadata] | where_exp: 'item', 'item.date' -%}
+{%- assign items = items | where_exp: 'item', 'item.format contains "image"' -%}
 {
     "title": {
         "media": {


### PR DESCRIPTION
Not sure why the original 'item.format' wasn't working, but it does work properly when we change items to two separate lines. 

This is a trick if you needed to do subsets of data and you want it to be human-readable - see how we create items as a variable on line 7 and then reuse that variable on line 8 to narrow it down. See if this works in your repo!